### PR TITLE
Create pull_request_template.md

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,20 @@
+# Description
+- List a brief description of the included changes
+- ...
+
+# Related information or background
+Describe any context or additional background describing why these changes were necessary
+
+# Checklist
+
+## Versioning
+- [ ] Version in `README.md` is incremented
+- [ ] Version in `HISTORY.md` is incremented
+- [ ] Version in `setup.py` is incremented
+
+## Testing
+- [ ] Are tests added or modified to cover code changes?
+- [ ] Are follow up work items created to add tests?
+
+## Documentation
+- [ ] Are any changes to public documentation, `README.md`, etc necessary to support these changes?

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -3,7 +3,7 @@
 - ...
 
 # Related information or background
-Describe any context or additional background describing why these changes were necessary
+Describe any context or additional background describing why these changes are necessary
 
 # Checklist
 


### PR DESCRIPTION
As discussed, it would be nice if contributors to the python libraries were more readily made aware of the changes necessary to support new versions of the library.  This PR adds `pull_request_template.md` whose contents will automatically fill the body of PRs created in the project.

We originally discussed using `CONTRIBUTING.md` however this is more so for project best practices, style guide, etc.  It seems that `pull_request_template.md` makes more sense for us in this case.  Reviewers, would you agree?

[GitHub - About contributing guidelines](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/setting-guidelines-for-repository-contributors)
[GitHub - create a pull request template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository)