### PR TITLE
Fix variables

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # Version History
 
+## 0.10.14_preview / 2024-12-26
+
+- Fixed issue where variables were not included in GraphQL request
+
 ## 0.10.13_preview / 2024-12-03
 
 - Fixed support for communities signups

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 | :loudspeaker: **Notice**: This library is an AVEVA Data Hub targeted version of the ocs_sample_library_preview. The ocs_sample_library_preview library is being deprecated and this library should be used moving forward. |
 | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 
-**Version:** 0.10.13_preview
+**Version:** 0.10.14_preview
 
 [![Build Status](https://dev.azure.com/osieng/engineering/_apis/build/status/product-readiness/ADH/aveva.sample-adh-sample_libraries-python?branchName=main)](https://dev.azure.com/osieng/engineering/_build/latest?definitionId=4674&branchName=main)
 

--- a/adh_sample_library_preview/GraphQL.py
+++ b/adh_sample_library_preview/GraphQL.py
@@ -14,7 +14,7 @@ class GraphQL(object):
 
         self.__setPathAndQueryTemplates()
 
-    def executeQuery(self, namespace_id: str, query: str, variables: str = None, operation_name: str = None, continuation: str = None, metrics: bool = None, data_class: type = None) -> Any:
+    def executeQuery(self, namespace_id: str, query: str, variables: dict = None, operation_name: str = None, continuation: str = None, metrics: bool = None, data_class: type = None) -> Any:
         """
         Executes a GraphQL Query or Mutation based on the query arguments of a GET request.
         It returns a GraphQLResponse in JSON format. The format of the response varies depending on the request.
@@ -34,7 +34,8 @@ class GraphQL(object):
         self.__base_client.validateParameters(namespace_id)
 
         request_body = {
-            'query': query
+            'query': query,
+            'variables': variables
         }
 
         params = {}

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as fh:
 
 setuptools.setup(
     name='adh_sample_library_preview',
-    version='0.10.13_preview',
+    version='0.10.14_preview',
     author='OSIsoft',
     license='Apache 2.0',
     author_email='samples@osisoft.com',


### PR DESCRIPTION
Added "variables" to the request body and changed the data type of variables in the executeQuery function to dict instead of string.
Without these changes, graphQL requests with variables do not work.