### PR TITLE
Fix regression calling Signups without CommunityId

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # Version History
 
+## 0.10.15_preview / 2025-01-29
+
+- Fixed regression calling Signups without CommunityId
+
 ## 0.10.14_preview / 2024-12-26
 
 - Fixed issue where variables were not included in GraphQL request

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,7 @@
 ## 0.10.15_preview / 2025-01-29
 
 - Fixed regression calling Signups without CommunityId
+- BREAKING CHANGE: to named parameters in Signups.createSignup and Signups.updateSignup
 
 ## 0.10.14_preview / 2024-12-26
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,7 +3,7 @@
 ## 0.10.15_preview / 2025-01-29
 
 - Fixed regression calling Signups without CommunityId
-- BREAKING CHANGE: to named parameters in Signups.createSignup and Signups.updateSignup
+- BREAKING CHANGE: Changes to parameter order in Signups.createSignup and Signups.updateSignup
 
 ## 0.10.14_preview / 2024-12-26
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 | :loudspeaker: **Notice**: This library is an AVEVA Data Hub targeted version of the ocs_sample_library_preview. The ocs_sample_library_preview library is being deprecated and this library should be used moving forward. |
 | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 
-**Version:** 0.10.14_preview
+**Version:** 0.10.15_preview
 
 [![Build Status](https://dev.azure.com/osieng/engineering/_apis/build/status/product-readiness/ADH/aveva.sample-adh-sample_libraries-python?branchName=main)](https://dev.azure.com/osieng/engineering/_build/latest?definitionId=4674&branchName=main)
 

--- a/adh_sample_library_preview/AbstractBaseClient.py
+++ b/adh_sample_library_preview/AbstractBaseClient.py
@@ -16,7 +16,7 @@ class AbstractBaseClient(ABC):
 
 
     @abstractmethod
-    def validateParameters(*args):
+    def validateRequiredParameters(*args):
         pass
 
 

--- a/adh_sample_library_preview/AuthorizationTags.py
+++ b/adh_sample_library_preview/AuthorizationTags.py
@@ -30,7 +30,7 @@ class AuthorizationTags(Securable, object):
         :param bool include_deleted: Parameter indicating whether to include soft-deleted Authorization Tags. If unspecified, a default value of false is used.
         :param str filter: 
         """
-        self.__base_client.validateParameters(namespace_id)
+        self.__base_client.validateRequiredParameters(namespace_id)
 
         params = {}
         if skip is not None:
@@ -64,7 +64,7 @@ class AuthorizationTags(Securable, object):
         :param str authorization_tag_id: The authorization tag identifier
         :param bool include_deleted: Parameter indicating whether to include soft-deleted Authorization Tags. If unspecified, a default value of false is used.
         """
-        self.__base_client.validateParameters(namespace_id, authorization_tag_id)
+        self.__base_client.validateRequiredParameters(namespace_id, authorization_tag_id)
 
         params = {}
         if include_deleted is not None:
@@ -89,7 +89,7 @@ class AuthorizationTags(Securable, object):
         :param AuthorizationTag authorization_tag: An authorization tag object
         """
 
-        self.__base_client.validateParameters(namespace_id, authorization_tag_id)
+        self.__base_client.validateRequiredParameters(namespace_id, authorization_tag_id)
 
         if not isinstance(authorization_tag, AuthorizationTag):
             raise TypeError
@@ -113,7 +113,7 @@ class AuthorizationTags(Securable, object):
         :param AuthorizationTag authorization_tag: An authorization tag object
         """
 
-        self.__base_client.validateParameters(namespace_id, authorization_tag_id)
+        self.__base_client.validateRequiredParameters(namespace_id, authorization_tag_id)
 
         if not isinstance(authorization_tag, AuthorizationTag):
             raise TypeError
@@ -135,7 +135,7 @@ class AuthorizationTags(Securable, object):
         :param str authorization_tag_id: The authorization tag identifier
         """
 
-        self.__base_client.validateParameters(namespace_id, authorization_tag_id)
+        self.__base_client.validateRequiredParameters(namespace_id, authorization_tag_id)
 
         response = self.__base_client.request('delete', self.__authorization_tag_path.format(
             namespace_id=namespace_id, authorization_tag_id=authorization_tag_id))
@@ -152,7 +152,7 @@ class AuthorizationTags(Securable, object):
         :param list[AuthorizationTag] authorization_tags: A list of authorization tag objects
         """
 
-        self.__base_client.validateParameters(namespace_id)
+        self.__base_client.validateRequiredParameters(namespace_id)
 
         if not isinstance(authorization_tags, list[AuthorizationTag]):
             raise TypeError

--- a/adh_sample_library_preview/BaseClient.py
+++ b/adh_sample_library_preview/BaseClient.py
@@ -148,7 +148,7 @@ class BaseClient(AbstractBaseClient):
 
     @staticmethod
     def getCommunityIdHeader(community_id: str) -> dict[str, str]:
-        return { 'Community-id': community_id }
+        return { 'Community-id': community_id } if community_id is not None else None 
 
 
     @staticmethod
@@ -204,7 +204,7 @@ class BaseClient(AbstractBaseClient):
             raise error
 
 
-    def validateParameters(*args):
+    def validateRequiredParameters(*args):
         for arg in args:
             if arg is None:
                 raise TypeError

--- a/adh_sample_library_preview/BaseClientStub.py
+++ b/adh_sample_library_preview/BaseClientStub.py
@@ -38,7 +38,7 @@ class BaseClientStub(AbstractBaseClient):
         return response
 
 
-    def validateParameters(*args):
+    def validateRequiredParameters(*args):
         for arg in args:
             if arg is None:
                 raise TypeError

--- a/adh_sample_library_preview/Enumerations.py
+++ b/adh_sample_library_preview/Enumerations.py
@@ -30,7 +30,7 @@ class Enumerations(Securable, object):
         :param bool include_deleted: Parameter indicating whether to include soft-deleted Enumerations. If unspecified, a default value of false is used.
         :param str filter: Parameter representing the condition for results to be filtered by. If unspecified, results are not filtered.
         """
-        self.__base_client.validateParameters(namespace_id)
+        self.__base_client.validateRequiredParameters(namespace_id)
 
         params = {}
         if skip is not None:
@@ -63,7 +63,7 @@ class Enumerations(Securable, object):
         :param Enumeration enumeration: An enumeration object
         """
 
-        self.__base_client.validateParameters(namespace_id)
+        self.__base_client.validateRequiredParameters(namespace_id)
 
         if not isinstance(enumeration, Enumeration):
             raise TypeError
@@ -86,7 +86,7 @@ class Enumerations(Securable, object):
         :param str enumeration_id: The enumeration identifier
         :param bool include_deleted: Parameter indicating whether to include soft-deleted Enumerations. If unspecified, a default value of false is used.
         """
-        self.__base_client.validateParameters(namespace_id, enumeration_id)
+        self.__base_client.validateRequiredParameters(namespace_id, enumeration_id)
 
         params = {}
         if include_deleted is not None:
@@ -111,7 +111,7 @@ class Enumerations(Securable, object):
         :param Enumeration enumeration: An enumeration object
         """
 
-        self.__base_client.validateParameters(namespace_id, enumeration_id)
+        self.__base_client.validateRequiredParameters(namespace_id, enumeration_id)
 
         if not isinstance(enumeration, Enumeration):
             raise TypeError
@@ -135,7 +135,7 @@ class Enumerations(Securable, object):
         :param Enumeration enumeration: An enumeration object
         """
 
-        self.__base_client.validateParameters(namespace_id, enumeration_id)
+        self.__base_client.validateRequiredParameters(namespace_id, enumeration_id)
 
         if not isinstance(enumeration, Enumeration):
             raise TypeError
@@ -157,7 +157,7 @@ class Enumerations(Securable, object):
         :param str enumeration_id: The enumeration identifier
         """
 
-        self.__base_client.validateParameters(namespace_id, enumeration_id)
+        self.__base_client.validateRequiredParameters(namespace_id, enumeration_id)
 
         response = self.__base_client.request('delete', self.__enumeration_path.format(
             namespace_id=namespace_id, enumeration_id=enumeration_id))
@@ -174,7 +174,7 @@ class Enumerations(Securable, object):
         :param list[Enumeration] enumerations: A list of enumeration objects
         """
 
-        self.__base_client.validateParameters(namespace_id)
+        self.__base_client.validateRequiredParameters(namespace_id)
 
         if not isinstance(enumerations, list[Enumeration]):
             raise TypeError

--- a/adh_sample_library_preview/EventTypes.py
+++ b/adh_sample_library_preview/EventTypes.py
@@ -30,7 +30,7 @@ class EventTypes(Securable, object):
         :param bool include_deleted: Parameter indicating whether to include soft-deleted EventTypes. If unspecified, a default value of false is used.
         :param str filter: Parameter representing the condition for results to be filtered by. If unspecified, results are not filtered.
         """
-        self.__base_client.validateParameters(namespace_id)
+        self.__base_client.validateRequiredParameters(namespace_id)
 
         params = {}
         if skip is not None:
@@ -63,7 +63,7 @@ class EventTypes(Securable, object):
         :param EventType event_type: An event type object
         """
 
-        self.__base_client.validateParameters(namespace_id)
+        self.__base_client.validateRequiredParameters(namespace_id)
 
         if not isinstance(event_type, EventType):
             raise TypeError
@@ -86,7 +86,7 @@ class EventTypes(Securable, object):
         :param str event_type_id: The id of the EventType.
         :param bool include_deleted: Parameter indicating whether to include soft-deleted EventTypes. If unspecified, a default value of false is used.
         """
-        self.__base_client.validateParameters(namespace_id, event_type_id)
+        self.__base_client.validateRequiredParameters(namespace_id, event_type_id)
 
         params = {}
         if include_deleted is not None:
@@ -111,7 +111,7 @@ class EventTypes(Securable, object):
         :param EventType event_type:  An event type object
         """
 
-        self.__base_client.validateParameters(namespace_id, event_type_id)
+        self.__base_client.validateRequiredParameters(namespace_id, event_type_id)
 
         if not isinstance(event_type, EventType):
             raise TypeError
@@ -135,7 +135,7 @@ class EventTypes(Securable, object):
         :param EventType event_type:  An event type object
         """
 
-        self.__base_client.validateParameters(namespace_id, event_type_id)
+        self.__base_client.validateRequiredParameters(namespace_id, event_type_id)
 
         if not isinstance(event_type, EventType):
             raise TypeError
@@ -157,7 +157,7 @@ class EventTypes(Securable, object):
         :param str event_type_id: The id of the EventType.
         """
 
-        self.__base_client.validateParameters(namespace_id, event_type_id)
+        self.__base_client.validateRequiredParameters(namespace_id, event_type_id)
 
         response = self.__base_client.request('delete', self.__event_type_path.format(
             namespace_id=namespace_id, event_type_id=event_type_id))
@@ -174,7 +174,7 @@ class EventTypes(Securable, object):
         :param list[EventType] event_types: A list list event type objects
         """
 
-        self.__base_client.validateParameters(namespace_id)
+        self.__base_client.validateRequiredParameters(namespace_id)
 
         if not isinstance(event_types, list[EventType]):
             raise TypeError

--- a/adh_sample_library_preview/Events.py
+++ b/adh_sample_library_preview/Events.py
@@ -44,7 +44,7 @@ class Events(Securable, object):
             If None returns a dynamic Python object from the data.
         """
 
-        self.__base_client.validateParameters(namespace_id, event_type_id)
+        self.__base_client.validateRequiredParameters(namespace_id, event_type_id)
 
         params = {}
         params['typeId'] = event_type_id
@@ -88,7 +88,7 @@ class Events(Securable, object):
             Type must support .fromJson()  Default is None.
             If None returns a dynamic Python object from the data.
         """
-        self.__base_client.validateParameters(namespace_id, event_type_id, events)
+        self.__base_client.validateRequiredParameters(namespace_id, event_type_id, events)
 
         params = {}
         params['typeId'] = event_type_id
@@ -120,7 +120,7 @@ class Events(Securable, object):
         :param event_type_id: The event TypeId being deleted.
         :param event_id: The event id to delete.
         """
-        self.__base_client.validateParameters(namespace_id, event_type_id, event_id)
+        self.__base_client.validateRequiredParameters(namespace_id, event_type_id, event_id)
 
         params = {}
         params['typeId'] = event_type_id

--- a/adh_sample_library_preview/GraphQL.py
+++ b/adh_sample_library_preview/GraphQL.py
@@ -31,7 +31,7 @@ class GraphQL(object):
             If None returns a dynamic Python object from the data.
         """
 
-        self.__base_client.validateParameters(namespace_id)
+        self.__base_client.validateRequiredParameters(namespace_id)
 
         request_body = {
             'query': query,
@@ -77,7 +77,7 @@ class GraphQL(object):
         :param namespace_id: id of namespace to work against
         """
 
-        self.__base_client.validateParameters(namespace_id)
+        self.__base_client.validateRequiredParameters(namespace_id)
         response = self.__base_client.request('post', self.__graph_ql_schema_path.format(
             namespace_id=namespace_id), data=body, additional_headers={'Content-type': 'text/plain'})
         self.__base_client.checkResponse(

--- a/adh_sample_library_preview/ReferenceData.py
+++ b/adh_sample_library_preview/ReferenceData.py
@@ -44,7 +44,7 @@ class ReferenceData(Securable, object):
             If None returns a dynamic Python object from the data.
         """
 
-        self.__base_client.validateParameters(namespace_id, reference_data_type_id)
+        self.__base_client.validateRequiredParameters(namespace_id, reference_data_type_id)
 
         params = {}
         params['typeId'] = self.__base_client.encode(reference_data_type_id)
@@ -91,7 +91,7 @@ class ReferenceData(Securable, object):
             Type must support .fromJson()  Default is None.
             If None returns a dynamic Python object from the data.
         """
-        self.__base_client.validateParameters(
+        self.__base_client.validateRequiredParameters(
             namespace_id, reference_data_type_id, reference_data
         )
 
@@ -132,7 +132,7 @@ class ReferenceData(Securable, object):
         :param reference_data_type_id: The reference data TypeId being deleted.
         :param reference_data_id: The reference data id to delete.
         """
-        self.__base_client.validateParameters(
+        self.__base_client.validateRequiredParameters(
             namespace_id, reference_data_type_id, reference_data_id
         )
 

--- a/adh_sample_library_preview/ReferenceDataTypes.py
+++ b/adh_sample_library_preview/ReferenceDataTypes.py
@@ -30,7 +30,7 @@ class ReferenceDataTypes(Securable, object):
         :param bool include_deleted: Parameter indicating whether to include soft-deleted ReferenceDataTypes. If unspecified, a default value of false is used.
         :param str filter: Parameter representing the condition for results to be filtered by. If unspecified, results are not filtered.
         """
-        self.__base_client.validateParameters(namespace_id)
+        self.__base_client.validateRequiredParameters(namespace_id)
 
         params = {}
         if skip is not None:
@@ -63,7 +63,7 @@ class ReferenceDataTypes(Securable, object):
         :param ReferenceDataType reference_data_type: A reference data type object
         """
 
-        self.__base_client.validateParameters(namespace_id)
+        self.__base_client.validateRequiredParameters(namespace_id)
 
         if not isinstance(reference_data_type, ReferenceDataType):
             raise TypeError
@@ -86,7 +86,7 @@ class ReferenceDataTypes(Securable, object):
         :param str reference_data_type_id: The id of the ReferenceDataType. 
         :param bool include_deleted: Parameter indicating whether to include soft-deleted ReferenceDataTypes. If unspecified, a default value of false is used.
         """
-        self.__base_client.validateParameters(namespace_id, reference_data_type_id)
+        self.__base_client.validateRequiredParameters(namespace_id, reference_data_type_id)
 
         params = {}
         if include_deleted is not None:
@@ -111,7 +111,7 @@ class ReferenceDataTypes(Securable, object):
         :param ReferenceDataType reference_data_type: A reference data type object
         """
 
-        self.__base_client.validateParameters(namespace_id, reference_data_type_id)
+        self.__base_client.validateRequiredParameters(namespace_id, reference_data_type_id)
 
         if not isinstance(reference_data_type, ReferenceDataType):
             raise TypeError
@@ -135,7 +135,7 @@ class ReferenceDataTypes(Securable, object):
         :param ReferenceDataType reference_data_type: A reference data type object
         """
 
-        self.__base_client.validateParameters(namespace_id, reference_data_type_id)
+        self.__base_client.validateRequiredParameters(namespace_id, reference_data_type_id)
 
         if not isinstance(reference_data_type, ReferenceDataType):
             raise TypeError
@@ -157,7 +157,7 @@ class ReferenceDataTypes(Securable, object):
         :param str reference_data_type_id: The id of the ReferenceDataType. 
         """
 
-        self.__base_client.validateParameters(namespace_id, reference_data_type_id)
+        self.__base_client.validateRequiredParameters(namespace_id, reference_data_type_id)
 
         response = self.__base_client.request('delete', self.__reference_data_type_path.format(
             namespace_id=namespace_id, reference_data_type_id=reference_data_type_id))
@@ -174,7 +174,7 @@ class ReferenceDataTypes(Securable, object):
         :param list[ReferenceDataType] reference_data_types: 
         """
 
-        self.__base_client.validateParameters(namespace_id)
+        self.__base_client.validateRequiredParameters(namespace_id)
 
         if not isinstance(reference_data_types, list[ReferenceDataType]):
             raise TypeError

--- a/adh_sample_library_preview/Signups.py
+++ b/adh_sample_library_preview/Signups.py
@@ -33,7 +33,7 @@ class Signups(object):
         :param str community_id: Community unique identifier.
         """
 
-        self.__base_client.validateParameters(namespace_id, community_id)
+        self.__base_client.validateRequiredParameters(namespace_id)
         
         additional_headers = BaseClient.getCommunityIdHeader(community_id)
 
@@ -49,8 +49,8 @@ class Signups(object):
 
     def createSignup(self,
                      namespace_id: str = None,
-                     community_id: str = None,
-                     body: CreateSignupInput = None) -> Signup:
+                     body: CreateSignupInput = None,
+                     community_id: str = None) -> Signup:
         """
         Creates a signup for the list of resource identifiers provided. 
 
@@ -59,7 +59,7 @@ class Signups(object):
         :param CreateSignupInput body: Input of the signup to be created.
         """
 
-        self.__base_client.validateParameters(namespace_id, community_id)
+        self.__base_client.validateRequiredParameters(namespace_id)
 
         additional_headers = BaseClient.getCommunityIdHeader(community_id)
 
@@ -85,7 +85,7 @@ class Signups(object):
         :param str signup_id: Signup Identifier.
         """
 
-        self.__base_client.validateParameters(namespace_id, signup_id, community_id)
+        self.__base_client.validateRequiredParameters(namespace_id, signup_id)
 
         additional_headers = BaseClient.getCommunityIdHeader(community_id)
 
@@ -101,8 +101,8 @@ class Signups(object):
     def updateSignup(self,
                      namespace_id: str = None,
                      signup_id: str = None,
-                     community_id: str = None,
-                     body: UpdateSignupInput = None,) -> Signup:
+                     body: UpdateSignupInput = None,
+                     community_id: str = None) -> Signup:
         """
         Updates the properties (for example, name) of a signup. 
 
@@ -111,7 +111,7 @@ class Signups(object):
         :param UpdateSignupInput body: Signup input object to replace the existing signup's properties.
         """
 
-        self.__base_client.validateParameters(namespace_id, signup_id, community_id, body)
+        self.__base_client.validateRequiredParameters(namespace_id, signup_id, body)
         
         additional_headers = BaseClient.getCommunityIdHeader(community_id)
 
@@ -134,7 +134,7 @@ class Signups(object):
         :param str signup_id: Signup unique identifier
         """
 
-        self.__base_client.validateParameters(namespace_id, signup_id, community_id)
+        self.__base_client.validateRequiredParameters(namespace_id, signup_id)
 
         additional_headers = BaseClient.getCommunityIdHeader(community_id)
 
@@ -153,7 +153,7 @@ class Signups(object):
         :param str namespace_id: id of namespace to work against
         :param str signup_id: Signup unique identifier
         """
-        self.__base_client.validateParameters(namespace_id, signup_id, community_id)
+        self.__base_client.validateRequiredParameters(namespace_id, signup_id)
         
         additional_headers = BaseClient.getCommunityIdHeader(community_id)
 
@@ -175,7 +175,7 @@ class Signups(object):
         :param str namespace_id: id of namespace to work against
         :param str signup_id: Signup unique identifier
         """
-        self.__base_client.validateParameters(namespace_id, signup_id, community_id)
+        self.__base_client.validateRequiredParameters(namespace_id, signup_id)
         
         additional_headers = BaseClient.getCommunityIdHeader(community_id)
 
@@ -191,8 +191,8 @@ class Signups(object):
     def updateSignupResources(self,
                               namespace_id: str = None,
                               signup_id: str = None,
-                              community_id: str = None,
-                              body: SignupResourcesInput = None):
+                              body: SignupResourcesInput = None,
+                              community_id: str = None):
         """
         Update Signup Resources. 
 
@@ -202,7 +202,7 @@ class Signups(object):
         :param SignupResourcesInput body: Signup resources input object to replace signup's resources.
         """
 
-        self.__base_client.validateParameters(namespace_id, signup_id, community_id, body)
+        self.__base_client.validateRequiredParameters(namespace_id, signup_id, body)
 
         additional_headers = BaseClient.getCommunityIdHeader(community_id)
 
@@ -224,8 +224,7 @@ class Signups(object):
         :param str bookmark: An encoded token representing a sequential starting point from which updates are to be retrieved for the current request. A request URI including a starter Bookmark token is provided in the 'Get-Updates' header of a successful Signup activation response.
         """
 
-        self.__base_client.validateParameters(
-            namespace_id, signup_id, community_id)
+        self.__base_client.validateRequiredParameters(namespace_id, signup_id)
         
         additional_headers = BaseClient.getCommunityIdHeader(community_id)
 

--- a/adh_sample_library_preview/Signups.py
+++ b/adh_sample_library_preview/Signups.py
@@ -55,8 +55,8 @@ class Signups(object):
         Creates a signup for the list of resource identifiers provided. 
 
         :param str namespace_id: id of namespace to work against
-        :param str community_id: Community unique identifier. Represents a signup for resources shared to the specified Community Id.
         :param CreateSignupInput body: Input of the signup to be created.
+        :param str community_id: Unique Community Identifier.
         """
 
         self.__base_client.validateRequiredParameters(namespace_id)
@@ -83,6 +83,7 @@ class Signups(object):
 
         :param str namespace_id: id of namespace to work against
         :param str signup_id: Signup Identifier.
+        :param str community_id: Unique Community Identifier.
         """
 
         self.__base_client.validateRequiredParameters(namespace_id, signup_id)
@@ -109,6 +110,7 @@ class Signups(object):
         :param str namespace_id: id of namespace to work against
         :param str signup_id: Signup Identifier.
         :param UpdateSignupInput body: Signup input object to replace the existing signup's properties.
+        :param str community_id: Unique Community Identifier.
         """
 
         self.__base_client.validateRequiredParameters(namespace_id, signup_id, body)
@@ -132,6 +134,7 @@ class Signups(object):
 
         :param str namespace_id: id of namespace to work against
         :param str signup_id: Signup unique identifier
+        :param str community_id: Unique Community Identifier.
         """
 
         self.__base_client.validateRequiredParameters(namespace_id, signup_id)
@@ -152,6 +155,7 @@ class Signups(object):
 
         :param str namespace_id: id of namespace to work against
         :param str signup_id: Signup unique identifier
+        :param str community_id: Unique Community Identifier.
         """
         self.__base_client.validateRequiredParameters(namespace_id, signup_id)
         
@@ -174,6 +178,7 @@ class Signups(object):
 
         :param str namespace_id: id of namespace to work against
         :param str signup_id: Signup unique identifier
+        :param str community_id: Unique Community Identifier.
         """
         self.__base_client.validateRequiredParameters(namespace_id, signup_id)
         
@@ -198,8 +203,8 @@ class Signups(object):
 
         :param str namespace_id: id of namespace to work against
         :param str signup_id: Unique Signup Identifier.
-        :param str community_id: Unique Community Identifier.
         :param SignupResourcesInput body: Signup resources input object to replace signup's resources.
+        :param str community_id: Unique Community Identifier.
         """
 
         self.__base_client.validateRequiredParameters(namespace_id, signup_id, body)
@@ -222,6 +227,7 @@ class Signups(object):
         :param str namespace_id: The namespace identifier.
         :param str signup_id: The signup identifier.
         :param str bookmark: An encoded token representing a sequential starting point from which updates are to be retrieved for the current request. A request URI including a starter Bookmark token is provided in the 'Get-Updates' header of a successful Signup activation response.
+        :param str community_id: Unique Community Identifier.
         """
 
         self.__base_client.validateRequiredParameters(namespace_id, signup_id)

--- a/adh_sample_library_preview/Streams.py
+++ b/adh_sample_library_preview/Streams.py
@@ -36,7 +36,7 @@ class Streams(PatchableSecurable, object):
         :param stream_id: id of the stream
         :return:the Stream as SdsStream
         """
-        self.__base_client.validateParameters(namespace_id, stream_id)
+        self.__base_client.validateRequiredParameters(namespace_id, stream_id)
         
         response = self.__base_client.request(
             'GET',
@@ -80,7 +80,7 @@ class Streams(PatchableSecurable, object):
         :param stream_id: id of the stream
         :return: the stream type as an SdsType
         """
-        self.__base_client.validateParameters(namespace_id, stream_id)
+        self.__base_client.validateRequiredParameters(namespace_id, stream_id)
 
         response = self.__base_client.request(
             'GET',
@@ -104,7 +104,7 @@ class Streams(PatchableSecurable, object):
         :param count: number of streams to limit to
         :return: array of SdsStreams
         """
-        self.__base_client.validateParameters(namespace_id, query)
+        self.__base_client.validateRequiredParameters(namespace_id, query)
 
         response = self.__base_client.request(
             'GET',
@@ -124,7 +124,7 @@ class Streams(PatchableSecurable, object):
         :param stream: the stream to Create or retrieve, as a SDsStream
         :return: the created Stream as an SdsStream
         """
-        self.__base_client.validateParameters(namespace_id, stream)
+        self.__base_client.validateRequiredParameters(namespace_id, stream)
         if stream is None or not isinstance(stream, SdsStream):
             raise TypeError
 
@@ -148,7 +148,7 @@ class Streams(PatchableSecurable, object):
         :param stream: the stream to Create or update, as a SDsStream
         :return: the created or updated Stream as an SdsStream
         """
-        self.__base_client.validateParameters(namespace_id, stream)
+        self.__base_client.validateRequiredParameters(namespace_id, stream)
         if not isinstance(stream, SdsStream):
             raise TypeError
 
@@ -171,7 +171,7 @@ class Streams(PatchableSecurable, object):
         :param stream_view_id: if of the streamview to change the type to
         :return:
         """
-        self.__base_client.validateParameters(namespace_id, stream_id, stream_view_id)
+        self.__base_client.validateRequiredParameters(namespace_id, stream_id, stream_view_id)
 
         response = self.__base_client.request(
             'PUT',
@@ -191,7 +191,7 @@ class Streams(PatchableSecurable, object):
         :param stream_id: id of the stream to delete
         :return:
         """
-        self.__base_client.validateParameters(namespace_id, stream_id)
+        self.__base_client.validateRequiredParameters(namespace_id, stream_id)
 
         response = self.__base_client.request(
             'DELETE',
@@ -211,7 +211,7 @@ class Streams(PatchableSecurable, object):
         :param tags: tags to create or update. expected for is an array of strings
         :return:
         """
-        self.__base_client.validateParameters(namespace_id)
+        self.__base_client.validateRequiredParameters(namespace_id)
 
         response = self.__base_client.request(
             'PUT',
@@ -232,7 +232,7 @@ class Streams(PatchableSecurable, object):
         :param metadata: metadata to create or update. expected for is an dict(string,string)
         :return:
         """
-        self.__base_client.validateParameters(namespace_id)
+        self.__base_client.validateRequiredParameters(namespace_id)
 
         response = self.__base_client.request(
             'PUT',
@@ -253,7 +253,7 @@ class Streams(PatchableSecurable, object):
         :param patch: a JSON patch document
         :return:
         """
-        self.__base_client.validateParameters(namespace_id)
+        self.__base_client.validateRequiredParameters(namespace_id)
 
         response = self.__base_client.request(
             'PATCH',
@@ -273,7 +273,7 @@ class Streams(PatchableSecurable, object):
         :param stream_id: id of the stream to get the tags of
         :return: stream's tags
         """
-        self.__base_client.validateParameters(namespace_id)
+        self.__base_client.validateRequiredParameters(namespace_id)
 
         response = self.__base_client.request(
             'GET',
@@ -295,7 +295,7 @@ class Streams(PatchableSecurable, object):
         :param key: specific metadata field to retrieve
         :return: value at the key
         """
-        self.__base_client.validateParameters(namespace_id)
+        self.__base_client.validateRequiredParameters(namespace_id)
 
         response = self.__base_client.request(
             'GET',
@@ -327,7 +327,7 @@ class Streams(PatchableSecurable, object):
         :return: the value.  If value_class is defined it is in this type.
             Otherwise it is a dynamic Python object
         """
-        self.__base_client.validateParameters(namespace_id, stream_id, index)
+        self.__base_client.validateRequiredParameters(namespace_id, stream_id, index)
 
         return self.getValueUrl(self.__stream_path.format(
             tenant_id=self.__tenant,
@@ -346,7 +346,7 @@ class Streams(PatchableSecurable, object):
         :return: the value.  If value_class is defined it is in this type.
             Otherwise it is a dynamic Python object
         """
-        self.__base_client.validateParameters(url, index)
+        self.__base_client.validateRequiredParameters(url, index)
 
         response = self.__base_client.request(
             'GET', self.__data_path.format(stream=url), params={'index': index}, additional_headers=additional_headers)
@@ -368,7 +368,7 @@ class Streams(PatchableSecurable, object):
         :return: the value.  If value_class is defined it is in this type.
             Otherwise it is a dynamic Python object
         """
-        self.__base_client.validateParameters(namespace_id, stream_id)
+        self.__base_client.validateRequiredParameters(namespace_id, stream_id)
 
         return self.getFirstValueUrl(self.__stream_path.format(
             tenant_id=self.__tenant,
@@ -387,7 +387,7 @@ class Streams(PatchableSecurable, object):
         :return: the value.  If value_class is defined it is in this type.
             Otherwise it is a dynamic Python object
         """
-        self.__base_client.validateParameters(url)
+        self.__base_client.validateRequiredParameters(url)
 
         response = self.__base_client.request(
             'GET', self.__first_path.format(stream=url), additional_headers=additional_headers)
@@ -409,7 +409,7 @@ class Streams(PatchableSecurable, object):
         :return: the value.  If value_class is defined it is in this type.
             Otherwise it is a dynamic Python object
         """
-        self.__base_client.validateParameters(namespace_id, stream_id)
+        self.__base_client.validateRequiredParameters(namespace_id, stream_id)
 
         return self.getLastValueUrl(self.__stream_path.format(
             tenant_id=self.__tenant,
@@ -428,7 +428,7 @@ class Streams(PatchableSecurable, object):
         :return: the value.  If value_class is defined it is in this type.
             Otherwise it is a dynamic Python object
         """
-        self.__base_client.validateParameters(url)
+        self.__base_client.validateRequiredParameters(url)
 
         response = self.__base_client.request(
             'GET', self.__last_path.format(stream=url), additional_headers=additional_headers)
@@ -455,7 +455,7 @@ class Streams(PatchableSecurable, object):
             If value_class is defined it is in this type.
             Otherwise it is a dynamic Python object
         """
-        self.__base_client.validateParameters(namespace_id, stream_id, start, end)
+        self.__base_client.validateRequiredParameters(namespace_id, stream_id, start, end)
 
         return self.getWindowValuesUrl(self.__stream_path.format(
             tenant_id=self.__tenant,
@@ -479,7 +479,7 @@ class Streams(PatchableSecurable, object):
             If value_class is defined it is in this type.
             Otherwise it is a dynamic Python object
         """
-        self.__base_client.validateParameters(url, start, end)
+        self.__base_client.validateRequiredParameters(url, start, end)
 
         response = self.__base_client.request(
             'GET', self.__data_path.format(stream=url),
@@ -517,7 +517,7 @@ class Streams(PatchableSecurable, object):
             If value_class is defined it is in this type.
             Otherwise it is a dynamic Python object
         """
-        self.__base_client.validateParameters(namespace_id, stream_id, start, end, count, continuation_token)
+        self.__base_client.validateRequiredParameters(namespace_id, stream_id, start, end, count, continuation_token)
 
         return self.getWindowValuesPagedUrl(self.__stream_path.format(
             tenant_id=self.__tenant,
@@ -553,7 +553,7 @@ class Streams(PatchableSecurable, object):
             If value_class is defined it is in this type.
             Otherwise it is a dynamic Python object
         """
-        self.__base_client.validateParameters(url, start, end, count, continuation_token)
+        self.__base_client.validateRequiredParameters(url, start, end, count, continuation_token)
 
         params = {'startIndex': start, 'endIndex': end, 'filter': filter,
                 'count': count, 'continuationToken': continuation_token}
@@ -592,7 +592,7 @@ class Streams(PatchableSecurable, object):
         :return: An array of the data in type specified if value_class
             defined.  Otherwise it is a dynamic Python object
         """
-        self.__base_client.validateParameters(namespace_id, stream_id, start, end)
+        self.__base_client.validateRequiredParameters(namespace_id, stream_id, start, end)
 
         return self.getWindowValuesFormUrl(self.__stream_path.format(
             tenant_id=self.__tenant,
@@ -616,7 +616,7 @@ class Streams(PatchableSecurable, object):
         :return: An array of the data in type specified if value_class
             defined.  Otherwise it is a dynamic Python object
         """
-        self.__base_client.validateParameters(url, start, start, end)
+        self.__base_client.validateRequiredParameters(url, start, start, end)
 
         response = self.__base_client.request(
             'GET', self.__data_path.format(stream=url), params={'startIndex': start, 'endIndex': end, 'form': form}, additional_headers=additional_headers)
@@ -649,7 +649,7 @@ class Streams(PatchableSecurable, object):
         :return: An array of the data in type specified if value_class
             is defined.  Otherwise it is a dynamic Python object
         """
-        self.__base_client.validateParameters(namespace_id, stream_id, start, skip, count, boundary_type)
+        self.__base_client.validateRequiredParameters(namespace_id, stream_id, start, skip, count, boundary_type)
         if reversed is None or not isinstance(reversed, bool):
             raise TypeError
 
@@ -683,7 +683,7 @@ class Streams(PatchableSecurable, object):
         :return: An array of the data in type specified if value_class
             is defined.  Otherwise it is a dynamic Python object
         """
-        self.__base_client.validateParameters(url, start, start, skip, count, boundary_type)
+        self.__base_client.validateRequiredParameters(url, start, start, skip, count, boundary_type)
         if reversed is None or not isinstance(reversed, bool):
             raise TypeError
 
@@ -720,7 +720,7 @@ class Streams(PatchableSecurable, object):
         :return: An array of the data in type specified if value_class is
         defined.  Otherwise it is a dynamic Python object
         """
-        self.__base_client.validateParameters(namespace_id, stream_id, start, end, count)
+        self.__base_client.validateRequiredParameters(namespace_id, stream_id, start, end, count)
 
         return self.getRangeValuesInterpolatedUrl(
             self.__stream_path.format(
@@ -746,7 +746,7 @@ class Streams(PatchableSecurable, object):
         :return: An array of the data in type specified if value_class is
         defined.  Otherwise it is a dynamic Python object
         """
-        self.__base_client.validateParameters(url, start, end, count)
+        self.__base_client.validateRequiredParameters(url, start, end, count)
 
         response = self.__base_client.request(
             'GET', self.__transform_interpolated_path.format(stream=url),
@@ -772,7 +772,7 @@ class Streams(PatchableSecurable, object):
         :return: An array of the data in type specified if value_class is
         defined.  Otherwise it is a dynamic Python object
         """
-        self.__base_client.validateParameters(namespace_id, stream_id, index)
+        self.__base_client.validateRequiredParameters(namespace_id, stream_id, index)
 
         return self.getIndexCollectionValuesUrl(
             self.__stream_path.format(
@@ -797,7 +797,7 @@ class Streams(PatchableSecurable, object):
         :return: An array of the data in type specified if value_class is
         defined.  Otherwise it is a dynamic Python object
         """
-        self.__base_client.validateParameters(url, index)
+        self.__base_client.validateRequiredParameters(url, index)
 
         params = []
         for i in index:
@@ -837,7 +837,7 @@ class Streams(PatchableSecurable, object):
         :return: An array of the data in type specified if value_class is
             defined.  Otherwise it is a dynamic Python object
         """
-        self.__base_client.validateParameters(namespace_id, stream_id, start, end, sample_by, intervals)
+        self.__base_client.validateRequiredParameters(namespace_id, stream_id, start, end, sample_by, intervals)
 
         return self.getSampledValuesUrl(self.__stream_path.format(
             tenant_id=self.__tenant,
@@ -870,7 +870,7 @@ class Streams(PatchableSecurable, object):
         :return: An array of the data in type specified if value_class is
             defined.  Otherwise it is a dynamic Python object
         """
-        self.__base_client.validateParameters(url, start, end, sample_by, intervals)
+        self.__base_client.validateRequiredParameters(url, start, end, sample_by, intervals)
 
         # if stream_view_id is set, use /transform/ route
         if len(stream_view_id):
@@ -913,7 +913,7 @@ class Streams(PatchableSecurable, object):
         :return: An array of the data summary in type specified if value_class
             is defined.  Otherwise it is a dynamic Python object
         """
-        self.__base_client.validateParameters(namespace_id, stream_id, start, end, count)
+        self.__base_client.validateRequiredParameters(namespace_id, stream_id, start, end, count)
 
         return self.getSummariesUrl(self.__stream_path.format(
             tenant_id=self.__tenant,
@@ -939,7 +939,7 @@ class Streams(PatchableSecurable, object):
         :return: An array of the data summary in type specified if value_class
             is defined.  Otherwise it is a dynamic Python object
         """
-        self.__base_client.validateParameters(url, start, end, count)
+        self.__base_client.validateRequiredParameters(url, start, end, count)
 
         paramsToUse = {'startIndex': start,
                         'endIndex': end,
@@ -971,7 +971,7 @@ class Streams(PatchableSecurable, object):
             Can be an array of values of a type that has toJson defined.
         :return:
         """
-        self.__base_client.validateParameters(namespace_id, stream_id, values)
+        self.__base_client.validateRequiredParameters(namespace_id, stream_id, values)
 
         if callable(getattr(values[0], 'toJson', None)):
             events = []
@@ -1003,7 +1003,7 @@ class Streams(PatchableSecurable, object):
         Can be an array of values of a type that has toJson defined.
         :return:
         """
-        self.__base_client.validateParameters(namespace_id, stream_id, values)
+        self.__base_client.validateRequiredParameters(namespace_id, stream_id, values)
 
         if callable(getattr(values[0], 'toJson', None)):
             events = []
@@ -1035,7 +1035,7 @@ class Streams(PatchableSecurable, object):
             Can be an array of values of a type that has toJson defined.
         :return:
         """
-        self.__base_client.validateParameters(namespace_id, stream_id, values)
+        self.__base_client.validateRequiredParameters(namespace_id, stream_id, values)
 
         if callable(getattr(values[0], 'toJson', None)):
             events = []
@@ -1065,7 +1065,7 @@ class Streams(PatchableSecurable, object):
         :param key: the index to remove
         :return:
         """
-        self.__base_client.validateParameters(namespace_id, stream_id, key)
+        self.__base_client.validateRequiredParameters(namespace_id, stream_id, key)
 
         response = self.__base_client.request(
             'DELETE',
@@ -1088,7 +1088,7 @@ class Streams(PatchableSecurable, object):
         :param end: ending index
         :return:
         """
-        self.__base_client.validateParameters(namespace_id, stream_id, start, end)
+        self.__base_client.validateRequiredParameters(namespace_id, stream_id, start, end)
 
         response = self.__base_client.request(
             'delete',
@@ -1120,7 +1120,7 @@ class Streams(PatchableSecurable, object):
             If value_class is defined it is in this type.
             Otherwise it is a dynamic Python object
         """
-        self.__base_client.validateParameters(namespace_id, stream_ids, start, end, join_mode)
+        self.__base_client.validateRequiredParameters(namespace_id, stream_ids, start, end, join_mode)
     
         response = self.__base_client.request(
             'GET',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as fh:
 
 setuptools.setup(
     name='adh_sample_library_preview',
-    version='0.10.14_preview',
+    version='0.10.15_preview',
     author='OSIsoft',
     license='Apache 2.0',
     author_email='samples@osisoft.com',


### PR DESCRIPTION
# Description
- Resolve `TypeError` thrown when calling Signups routes without community id

# Related information or background
`ValidateParameters` was only checking and throwing on `None` inputs, and is only valid for required params.  Renamed this method to `ValidateRequiredParameters`
# Checklist

## Versioning
- [x] Version in `README.md` is incremented
- [x] Version in `HISTORY.md` is incremented
- [x] Version in `setup.py` is incremented

## Testing
- [ ] Are tests added or modified to cover code changes?
- [ ] Are follow up work items created to add tests?

## Documentation
- [x] Are any changes to public documentation, `README.md`, etc necessary to support these changes?
 No