### PR TITLE
Add Name field to Namespace class definition

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # Version History
 
+## 0.10.20_preview / 2026-06-24
+
+- Added Name property to Namespace class definition
+
 ## 0.10.19_preview / 2025-10-23
 
 - Fixed issue where event type property Uom and description fields are swapped

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 | :loudspeaker: **Notice**: This library is an AVEVA Data Hub targeted version of the ocs_sample_library_preview. The ocs_sample_library_preview library is being deprecated and this library should be used moving forward. |
 | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 
-**Version:** 0.10.19_preview
+**Version:** 0.10.20_preview
 
 [![Build Status](https://dev.azure.com/osieng/engineering/_apis/build/status/product-readiness/ADH/aveva.sample-adh-sample_libraries-python?branchName=main)](https://dev.azure.com/osieng/engineering/_build/latest?definitionId=4674&branchName=main)
 

--- a/adh_sample_library_preview/Tenant/Namespace.py
+++ b/adh_sample_library_preview/Tenant/Namespace.py
@@ -9,12 +9,13 @@ from .NamespaceProvisioningState import NamespaceProvisioningState
 class Namespace(object):
     """ADH namespace definition"""
 
-    def __init__(self, id: str = None, region: str = None, namespace_self: str = None, description: str = None, state: NamespaceProvisioningState = None,
+    def __init__(self, id: str = None, region: str = None, namespace_self: str = None, description: str = None, name: str = None, state: NamespaceProvisioningState = None,
                  owner: Trustee = None, access_control: AccessControlList = None, region_id: str = None, instance_id: str = None):
         self.Id = id
         self.Region = region
         self.Self = namespace_self
         self.Description = description
+        self.Name = name
         self.State = state
         self.Owner = owner
         self.AccessControl = access_control
@@ -52,6 +53,14 @@ class Namespace(object):
     @Description.setter
     def Description(self, value: str):
         self.__description = value
+
+    @property
+    def Name(self) -> str:
+        return self.__name
+
+    @Name.setter
+    def Name(self, value: str):
+        self.__name = value
 
     @property
     def State(self) -> NamespaceProvisioningState:
@@ -108,6 +117,9 @@ class Namespace(object):
         if self.Description is not None:
             result['Description'] = self.Description
 
+        if self.Name is not None:
+            result['Name'] = self.Name
+
         if self.State is not None:
             result['State'] = self.State.value
 
@@ -143,6 +155,9 @@ class Namespace(object):
 
         if 'Description' in content:
             result.Description = content['Description']
+
+        if 'Name' in content:
+            result.Name = content['Name']
 
         if 'State' in content:
             result.State = content['State']

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as fh:
 
 setuptools.setup(
     name='adh_sample_library_preview',
-    version='0.10.19_preview',
+    version='0.10.20_preview',
     author='OSIsoft',
     license='Apache 2.0',
     author_email='samples@osisoft.com',


### PR DESCRIPTION
# Description
- Add Name property to Namespace class definition

# Related information or background
The name field is returned by the Namespaces API, but is not included in the Namespace class definition. This prevents accessing the Namespace name without extending the library.

# Checklist

## Versioning
- [x] Version in `README.md` is incremented
- [x] Version in `HISTORY.md` is incremented
- [x] Version in `setup.py` is incremented